### PR TITLE
Includes thru model, Plural in lookup endpoint.

### DIFF
--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -564,7 +564,7 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + relatedModel + 's/',
+						'lookupEndpoint': '/api/' + relatedSchema.plural + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});

--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -558,13 +558,14 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 					var related = theInstance ? theInstance[relation.name]() : [];
 					var relatedModel = relation.polymorphic ? theInstance[relation.polymorphic.discriminator] : relation.modelTo;
 					var relatedSchema = getModelInfo(relatedModel);
+					var pluralModelName = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
 					parents.push({
 						'name': relation.name,
 						'model': relatedModel,
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + relatedSchema.plural + '/',
+						'lookupEndpoint': '/api/' + pluralModelName + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});

--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -558,14 +558,14 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 					var related = theInstance ? theInstance[relation.name]() : [];
 					var relatedModel = relation.polymorphic ? theInstance[relation.polymorphic.discriminator] : relation.modelTo;
 					var relatedSchema = getModelInfo(relatedModel);
-					var pluralModelName = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
+					var relatedModelPlural = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
 					parents.push({
 						'name': relation.name,
 						'model': relatedModel,
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + pluralModelName + '/',
+						'lookupEndpoint': '/api/' + relatedModelPlural + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});


### PR DESCRIPTION
- Fix incorrect endpoint in lookup when model's name has a specific plural form.
- Fix if relatedSchema.plural is undefined, use the original code by adding suffix 's'.
- Fix the incorrect id when accessing through model.